### PR TITLE
My idea for using stale cache if riot breaks

### DIFF
--- a/optimlol_api/controllers/summonerController.js
+++ b/optimlol_api/controllers/summonerController.js
@@ -53,7 +53,7 @@ module.exports = function() {
 		var role = matchData.role;
 		if (role === "BOTTOM") {
 			role = champion.tags.indexOf("Marksman") === -1 ? "SUPPORT" : "MARKSMAN";
-		} 
+		}
 
 		recentStats[role].total++;
 		if (matchData.winner) {
@@ -148,7 +148,12 @@ module.exports = function() {
 				var championStats = results[promiseObject.STATS_INDEX].state === 'fulfilled' ? results[promiseObject.STATS_INDEX].value : null;
 				var recentHistoryStats = results[promiseObject.RECENT_STATS_INDEX].state === 'fulfilled' ? results[promiseObject.RECENT_STATS_INDEX].value : null;
 				var champions = results[promiseObject.CHAMPIONS_INDEX].state === 'fulfilled' ? results[promiseObject.CHAMPIONS_INDEX].value : null;
-				
+
+				summoner.dataQuality = "fresh";
+				if(championStats.quality === "stale" || recentHistoryStats.quality === "stale" || champions.quality === "stale") {
+					summoner.dataQuality = "stale";
+				}
+
 				summoner.championStats = null;
 				summoner.recentHistory = null;
 
@@ -175,12 +180,12 @@ module.exports = function() {
 
 				if (recentHistoryStats) {
 					var recentChampionsArray = [];
-					var laneStats = { 
-						MARKSMAN: {wins: 0, losses: 0, total: 0}, 
-						SUPPORT: {wins: 0, losses: 0, total: 0}, 
-						MIDDLE: {wins: 0, losses: 0, total: 0}, 
-						TOP: {wins: 0, losses: 0, total: 0}, 
-						JUNGLE: {wins: 0, losses: 0, total: 0} 
+					var laneStats = {
+						MARKSMAN: {wins: 0, losses: 0, total: 0},
+						SUPPORT: {wins: 0, losses: 0, total: 0},
+						MIDDLE: {wins: 0, losses: 0, total: 0},
+						TOP: {wins: 0, losses: 0, total: 0},
+						JUNGLE: {wins: 0, losses: 0, total: 0}
 					};
 
 					for(var champion in recentHistoryStats.champions) {


### PR DESCRIPTION
This will still reject all the way home if cache and riot api fails. 

Would need to update the other data providers to provide a data quality 

The ui would simply look at the dataQuality index of the returned object and display the proper message if the data is stale.... Let me know what you think about this. 
